### PR TITLE
Set default python version to 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 default_stages: [commit]
+default_language_version:
+  python: python3.8
 
 ci:
   autoupdate_commit_msg: 'chore(deps): pre-commit.ci autoupdate'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
     hooks:
       - id: mypy
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.16.0  # Last version to support Python 3.8
     hooks:
       - id: pyupgrade
         args: [--py38-plus]


### PR DESCRIPTION
We want to make sure that our minimum Python version 3.8 keeps working