### PR TITLE
Allow running check-ownership hook on another repo for testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,10 +85,10 @@ repos:
     hooks:
       - id: toml-sort-fix
         exclude: "\\.lock$"
-  # - repo: https://github.com/google/yamlfmt
-  #   rev: v0.14.0
-  #   hooks:
-  #     - id: yamlfmt
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.14.0
+    hooks:
+      - id: yamlfmt
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,10 +85,10 @@ repos:
     hooks:
       - id: toml-sort-fix
         exclude: "\\.lock$"
-  - repo: https://github.com/google/yamlfmt
-    rev: v0.14.0
-    hooks:
-      - id: yamlfmt
+  # - repo: https://github.com/google/yamlfmt
+  #   rev: v0.14.0
+  #   hooks:
+  #     - id: yamlfmt
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1
     hooks:

--- a/dev_tools/check_ownership.py
+++ b/dev_tools/check_ownership.py
@@ -184,14 +184,16 @@ def check_for_files_without_team_ownership(
 def parse_arguments() -> Namespace:
     parser = create_default_parser()
     parser.add_argument("--codeowners-owner", type=str, help="Team or person that should only own the CODEOWNERS file")
+    parser.add_argument(
+        "--repo-dir", type=Path, help="Path to the git repo that should be checked.", default=Path.cwd()
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_arguments()
-    repo_root = Path.cwd()
-    return perform_all_codeowners_checks(repo_root) | check_for_files_without_team_ownership(
-        repo_root, args.filenames, args.codeowners_owner
+    return perform_all_codeowners_checks(args.repo_dir) | check_for_files_without_team_ownership(
+        args.repo_dir, args.filenames, args.codeowners_owner
     )
 
 


### PR DESCRIPTION
Just add `--repo-dir` to run the hook on another git repo. This is useful when reproducing a problem in another repo while being able to change the hook code itself.