### PR TITLE
Optimize check ownership string/path operations

### DIFF
--- a/dev_tools/ownership_utils.py
+++ b/dev_tools/ownership_utils.py
@@ -4,7 +4,7 @@
 import re
 import subprocess
 import sys
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import Dict, Generator, Optional, Tuple
 
 
@@ -36,15 +36,14 @@ class GithubOwnerShip:
         return ()
 
     @staticmethod
-    def is_path_prefix(path: PurePath, prefix: PurePath) -> bool:
+    def is_path_prefix(path: str, prefix: str) -> bool:
         """Check if `prefix` is one of the parents of `path`, including itself."""
-        path_str, prefix_str = str(path), str(prefix)
-        if not path_str.startswith(prefix_str):
+        if not path.startswith(prefix):
             return False
-        path_length, prefix_length = len(path_str), len(prefix_str)
+        path_length, prefix_length = len(path), len(prefix)
         if path_length == prefix_length:
             return True
-        return path_str[prefix_length] == "/"
+        return path[prefix_length] == "/"
 
     def is_file_covered_by_pattern(self, filepath_in_repo: Path, pattern: str) -> bool:
         """Implements the complete featureset demonstrated at https://docs.github.com/en/repositories/managing-your-
@@ -53,8 +52,7 @@ class GithubOwnerShip:
         if "*" in pattern:
             return self._match_pattern_with_asterisks(filepath_string, filepath_in_repo.name, pattern)
         if pattern.startswith("/"):
-            pattern_path = Path(pattern[1:].rstrip("/"))
-            return GithubOwnerShip.is_path_prefix(path=filepath_in_repo, prefix=pattern_path)
+            return GithubOwnerShip.is_path_prefix(path=filepath_string, prefix=pattern[1:].rstrip("/"))
         return pattern.rstrip("/") in filepath_string
 
     def _match_pattern_with_asterisks(self, filepath_string: str, filename: str, pattern: str) -> bool:

--- a/dev_tools/ownership_utils.py
+++ b/dev_tools/ownership_utils.py
@@ -35,6 +35,17 @@ class GithubOwnerShip:
 
         return ()
 
+    @staticmethod
+    def is_path_prefix(path: Path, prefix: Path) -> bool:
+        """Check if `prefix` is one of the parents of `path`, including itself."""
+        path_str, prefix_str = str(path), str(prefix)
+        if not path_str.startswith(prefix_str):
+            return False
+        path_length, prefix_length = len(path_str), len(prefix_str)
+        if path_length == prefix_length:
+            return True
+        return path_str[prefix_length] == "/"
+
     def is_file_covered_by_pattern(self, filepath_in_repo: Path, pattern: str) -> bool:
         """Implements the complete featureset demonstrated at https://docs.github.com/en/repositories/managing-your-
         repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file."""
@@ -42,8 +53,8 @@ class GithubOwnerShip:
         if "*" in pattern:
             return self._match_pattern_with_asterisks(filepath_string, filepath_in_repo.name, pattern)
         if pattern.startswith("/"):
-            path_from_pattern = Path(pattern[1:].rstrip("/"))
-            return path_from_pattern == filepath_in_repo or path_from_pattern in filepath_in_repo.parents
+            pattern_path = Path(pattern[1:].rstrip("/"))
+            return GithubOwnerShip.is_path_prefix(path=filepath_in_repo, prefix=pattern_path)
         return pattern.rstrip("/") in filepath_string
 
     def _match_pattern_with_asterisks(self, filepath_string: str, filename: str, pattern: str) -> bool:

--- a/dev_tools/ownership_utils.py
+++ b/dev_tools/ownership_utils.py
@@ -4,7 +4,7 @@
 import re
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Dict, Generator, Optional, Tuple
 
 
@@ -36,7 +36,7 @@ class GithubOwnerShip:
         return ()
 
     @staticmethod
-    def is_path_prefix(path: Path, prefix: Path) -> bool:
+    def is_path_prefix(path: PurePath, prefix: PurePath) -> bool:
         """Check if `prefix` is one of the parents of `path`, including itself."""
         path_str, prefix_str = str(path), str(prefix)
         if not path_str.startswith(prefix_str):

--- a/dev_tools/ownership_utils.py
+++ b/dev_tools/ownership_utils.py
@@ -29,8 +29,9 @@ class GithubOwnerShip:
         return owners[0] if owners else None
 
     def get_owners(self, file: Path) -> Tuple[str, ...]:
+        file_relative = file.relative_to(self._repo_dir)
         for ownership in self._ownerships:
-            if self.is_file_covered_by_pattern(file.relative_to(self._repo_dir), ownership.pattern):
+            if self.is_file_covered_by_pattern(file_relative, ownership.pattern):
                 return ownership.owners
 
         return ()

--- a/dev_tools/ownership_utils.py
+++ b/dev_tools/ownership_utils.py
@@ -41,8 +41,8 @@ class GithubOwnerShip:
         """Check if `prefix` is one of the parents of `path`, including itself."""
         if not path.startswith(prefix):
             return False
-        path_length, prefix_length = len(path), len(prefix)
-        if path_length == prefix_length:
+        prefix_length = len(prefix)
+        if len(path) == prefix_length:
             return True
         return path[prefix_length] == "/"
 

--- a/tests/test_ownership_utils.py
+++ b/tests/test_ownership_utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) Luminar Technologies, Inc. All rights reserved.
 # Licensed under the MIT License.
 
-from pathlib import Path, PurePath
+from pathlib import Path
 
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
@@ -173,23 +173,23 @@ def test_get_ownership_entries_should_be_parsed_correctly(fs: FakeFilesystem) ->
 
 
 def test_is_file_covered_by_pattern__exact_entries__returns_true() -> None:
-    path = PurePath("a/b/c")
-    prefix = PurePath("a/b/c")
+    path = "a/b/c"
+    prefix = "a/b/c"
 
     assert GithubOwnerShip.is_path_prefix(path, prefix)
 
 
 @pytest.mark.parametrize("prefix", ["a/b", "a"])
 def test_is_file_covered_by_pattern__proper_prefix__returns_true(prefix: str) -> None:
-    path = PurePath("a/b/c")
-    prefix_path = PurePath(prefix)
+    path = "a/b/c"
+    prefix_path = prefix
 
     assert GithubOwnerShip.is_path_prefix(path, prefix_path)
 
 
 @pytest.mark.parametrize("prefix", ["aa", "a/bc"])
 def test_is_file_covered_by_pattern__not_a_prefix__returns_false(prefix: str) -> None:
-    path = PurePath("a/b/c")
-    prefix_path = PurePath(prefix)
+    path = "a/b/c"
+    prefix_path = prefix
 
     assert not GithubOwnerShip.is_path_prefix(path, prefix_path)

--- a/tests/test_ownership_utils.py
+++ b/tests/test_ownership_utils.py
@@ -1,8 +1,9 @@
 # Copyright (c) Luminar Technologies, Inc. All rights reserved.
 # Licensed under the MIT License.
 
-from pathlib import Path
+from pathlib import Path, PurePath
 
+import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 
 from dev_tools.ownership_utils import GithubOwnerShip, get_ownership_entries
@@ -169,3 +170,26 @@ def test_get_ownership_entries_should_be_parsed_correctly(fs: FakeFilesystem) ->
     assert len(result) == expect_entries_found
     assert result[0].owners == ("devs",)
     assert result[1].owners == ("devs", "management")
+
+
+def test_is_file_covered_by_pattern__exact_entries__returns_true() -> None:
+    path = PurePath("a/b/c")
+    prefix = PurePath("a/b/c")
+
+    assert GithubOwnerShip.is_path_prefix(path, prefix)
+
+
+@pytest.mark.parametrize("prefix", ["a/b", "a"])
+def test_is_file_covered_by_pattern__proper_prefix__returns_true(prefix: str) -> None:
+    path = PurePath("a/b/c")
+    prefix_path = PurePath(prefix)
+
+    assert GithubOwnerShip.is_path_prefix(path, prefix_path)
+
+
+@pytest.mark.parametrize("prefix", ["aa", "a/bc"])
+def test_is_file_covered_by_pattern__not_a_prefix__returns_false(prefix: str) -> None:
+    path = PurePath("a/b/c")
+    prefix_path = PurePath(prefix)
+
+    assert not GithubOwnerShip.is_path_prefix(path, prefix_path)


### PR DESCRIPTION
With these changes, the runtime of check-ownership on a bigger repo went down from 41s to 2.3s.

Running with cProfile added some overhead. But still, the profiler graph before was:
![Screenshot from 2024-11-07 16-31-10](https://github.com/user-attachments/assets/e6c976b9-c385-49ba-a91f-1697d31d46cc)

After:
![Screenshot from 2024-11-07 16-34-31](https://github.com/user-attachments/assets/64f5cc67-a8c8-470e-b71a-cdd85af45ef2)
