### PR TITLE
Improve cpp unit test naming scheme

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -26,7 +26,8 @@
     (?x)^(
       .*(?<=test)(?<!_test)\.(cpp|cu)$|
       .*_tests\.(cpp|cu)$|
-      .*/test/.*\.(cpp|cu)$
+      .*/test/.*\.(cpp|cu)$|
+      (?:(?!/tests/).)*_test\.(cpp|cu)$
     )
   types_or:
     - c++

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,13 +17,16 @@
     - shell
 - id: check-cpp-and-cu-unit-test-naming-pattern
   name: Check c++ and cu unit test naming pattern
-  description: Check that all C++ and Cuda unit test files end with `_test.cpp` or `_test.cu`.
-  entry: cpp and cu unit test files must end with _test.cpp
+  description: |-
+    Check that all C++ and Cuda unit test files end with `_test.cpp` or `_test.cu` (no `_tests`)
+    and that they're not in test folder (use /tests/).
+  entry: cpp and cu unit test files must conform to the naming pattern
   language: fail
   files: |
     (?x)^(
       .*(?<=test)(?<!_test)\.(cpp|cu)$|
-      .*_tests\.(cpp|cu)$
+      .*_tests\.(cpp|cu)$|
+      .*/test/.*\.(cpp|cu)$
     )
   types_or:
     - c++

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,7 +20,11 @@
   description: Check that all C++ and Cuda unit test files end with `_test.cpp` or `_test.cu`.
   entry: cpp and cu unit test files must end with _test.cpp
   language: fail
-  files: '.*(?<=test)(?<!_test)\.(cpp|cu)$'
+  files: |
+    (?x)^(
+      .*(?<=test)(?<!_test)\.(cpp|cu)$|
+      .*_tests\.(cpp|cu)$
+    )
   types_or:
     - c++
     - cuda

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Check that all source code files are `snake_case`. We don't want to use `camelCa
 
 ### `check-cpp-and-cu-unit-test-naming-pattern`
 
-Check that all C++ and Cuda unit test files end with `_test.cpp` or `_test.cu`.
+Check that all C++ and Cuda unit test files end with `_test.cpp` or `_test.cu` (no `_tests`)
+and that they're not in test folder (use /tests/).
 
 ### `check-no-dashes`
 

--- a/dev_tools/pre_commit_utils.py
+++ b/dev_tools/pre_commit_utils.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pre_commit.clientlib import load_manifest
+from pre_commit.constants import MANIFEST_FILE
+
+
+def get_hooks_manifest(repo_root: Path | None = None) -> list[dict]:
+    if repo_root is None:
+        repo_root = Path.cwd()
+
+    hooks_manifest = repo_root / MANIFEST_FILE
+    return list(load_manifest(hooks_manifest))

--- a/poetry.lock
+++ b/poetry.lock
@@ -248,13 +248,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "pyfakefs"
-version = "5.7.2"
+version = "5.7.3"
 description = "pyfakefs implements a fake file system that mocks the Python file system modules."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyfakefs-5.7.2-py3-none-any.whl", hash = "sha256:e1527b0e8e4b33be52f0b024ca1deb269c73eecd68457c6b0bf608d6dab12ebd"},
-    {file = "pyfakefs-5.7.2.tar.gz", hash = "sha256:40da84175c5af8d9c4f3b31800b8edc4af1e74a212671dd658b21cc881c60000"},
+    {file = "pyfakefs-5.7.3-py3-none-any.whl", hash = "sha256:53702780b38b24a48a9b8481c971abf1675f5abfd7d44653c2bcdd90b9751224"},
+    {file = "pyfakefs-5.7.3.tar.gz", hash = "sha256:cd53790761d0fc030a9cf41fd541bfd28c1ea681b1a7c5df8834f3c9e511ac5f"},
 ]
 
 [[package]]
@@ -361,13 +361,13 @@ files = [
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.18.6"
+version = "0.18.8"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruamel.yaml-0.18.6-py3-none-any.whl", hash = "sha256:57b53ba33def16c4f3d807c0ccbc00f8a6081827e81ba2491691b76882d0c636"},
-    {file = "ruamel.yaml-0.18.6.tar.gz", hash = "sha256:8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b"},
+    {file = "ruamel.yaml-0.18.8-py3-none-any.whl", hash = "sha256:a7c02af6ec9789495b4d19335addabc4d04ab1e0dad3e491c0c9457bbc881100"},
+    {file = "ruamel.yaml-0.18.8.tar.gz", hash = "sha256:1b7e14f28a4b8d09f8cd40dca158852db9b22ac84f22da5bb711def35cb5c548"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ select = ["ALL"]
 ignore = [
   "A00",
   "ANN001",
-  "ANN101",
   "COM812",
   "D",
   "E501", # Line length is the task of the formatter

--- a/tests/local/test_check_cpp_tests_pattern.py
+++ b/tests/local/test_check_cpp_tests_pattern.py
@@ -36,7 +36,9 @@ def test__hook_validating_test_filenames__allows_valid_cases(cpp_tests_name_hook
     assert not re.match(deny_files_pattern, filename), "Valid test filename should not match the deny pattern"
 
 
-@pytest.mark.parametrize("filename", ["src/tests/footest.cpp", "src/tests/foo_tests.cpp", "src/test/foo_test.cpp"])
+@pytest.mark.parametrize(
+    "filename", ["src/tests/footest.cpp", "src/tests/foo_tests.cpp", "src/test/foo_test.cpp", "src/foo_test.cu"]
+)
 def test__hook_validating_test_filenames__denies_invalid_cases(cpp_tests_name_hook: dict, filename: str) -> None:
     deny_files_pattern: str = cpp_tests_name_hook["files"]
     assert re.match(deny_files_pattern, filename), "Invalid test filename should match the deny pattern"

--- a/tests/local/test_check_cpp_tests_pattern.py
+++ b/tests/local/test_check_cpp_tests_pattern.py
@@ -32,10 +32,10 @@ def test__hook_validating_test_filenames__is_defined_for_files(cpp_tests_name_ho
 )
 def test__hook_validating_test_filenames__allows_valid_cases(cpp_tests_name_hook: dict, filename: str) -> None:
     deny_files_pattern: str = cpp_tests_name_hook["files"]
-    assert not re.match(deny_files_pattern, filename)
+    assert not re.match(deny_files_pattern, filename), "Valid test filename should not match the deny pattern"
 
 
-@pytest.mark.parametrize("filename", ["src/tests/footest.cpp", "src/tests/foo_tests.cpp"])
+@pytest.mark.parametrize("filename", ["src/tests/footest.cpp", "src/tests/foo_tests.cpp", "src/test/foo_test.cpp"])
 def test__hook_validating_test_filenames__denies_invalid_cases(cpp_tests_name_hook: dict, filename: str) -> None:
     deny_files_pattern: str = cpp_tests_name_hook["files"]
-    assert re.match(deny_files_pattern, filename)
+    assert re.match(deny_files_pattern, filename), "Invalid test filename should match the deny pattern"

--- a/tests/local/test_check_cpp_tests_pattern.py
+++ b/tests/local/test_check_cpp_tests_pattern.py
@@ -24,6 +24,7 @@ def test__hook_validating_test_filenames__is_defined_for_files(cpp_tests_name_ho
     [
         "src/tests/foo_test.cpp",
         "src/tests/foo_test.cu",
+        "src/tests/local/foo_test.cpp",
         "src/tests/pythontest.py",
         "src/tests/footest.cpp.txt",
         "src/python_tests/foo.py",

--- a/tests/local/test_check_cpp_tests_pattern.py
+++ b/tests/local/test_check_cpp_tests_pattern.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from dev_tools.pre_commit_utils import get_hooks_manifest
@@ -13,5 +15,27 @@ def cpp_tests_name_hook() -> dict:
     raise ValueError(msg)
 
 
-def test__hooks_manifest__contains_hook_validating_test_filenames(cpp_tests_name_hook: dict) -> None:
+def test__hook_validating_test_filenames__is_defined_for_files(cpp_tests_name_hook: dict) -> None:
     assert "files" in cpp_tests_name_hook
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "src/tests/foo_test.cpp",
+        "src/tests/foo_test.cu",
+        "src/tests/pythontest.py",
+        "src/tests/footest.cpp.txt",
+        "src/python_tests/foo.py",
+        "src/python_test/foo.py",
+    ],
+)
+def test__hook_validating_test_filenames__allows_valid_cases(cpp_tests_name_hook: dict, filename: str) -> None:
+    deny_files_pattern: str = cpp_tests_name_hook["files"]
+    assert not re.match(deny_files_pattern, filename)
+
+
+@pytest.mark.parametrize("filename", ["src/tests/footest.cpp", "src/tests/foo_tests.cpp"])
+def test__hook_validating_test_filenames__denies_invalid_cases(cpp_tests_name_hook: dict, filename: str) -> None:
+    deny_files_pattern: str = cpp_tests_name_hook["files"]
+    assert re.match(deny_files_pattern, filename)

--- a/tests/local/test_check_cpp_tests_pattern.py
+++ b/tests/local/test_check_cpp_tests_pattern.py
@@ -1,0 +1,17 @@
+import pytest
+
+from dev_tools.pre_commit_utils import get_hooks_manifest
+
+
+@pytest.fixture
+def cpp_tests_name_hook() -> dict:
+    hook_id = "check-cpp-and-cu-unit-test-naming-pattern"
+    for hook in get_hooks_manifest():
+        if hook["id"] == hook_id:
+            return hook
+    msg = f"{hook_id} not found in hooks manifest"
+    raise ValueError(msg)
+
+
+def test__hooks_manifest__contains_hook_validating_test_filenames(cpp_tests_name_hook: dict) -> None:
+    assert "files" in cpp_tests_name_hook


### PR DESCRIPTION
Added more rules to improve naming consistency. Ensure that all tests match `tests/**/*_test.cpp/cu`.