### PR TITLE
Configure renovate for pre-commit updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_stages: [pre-commit]
 
 ci:
   autoupdate_commit_msg: 'chore(deps): pre-commit.ci autoupdate'
-  autoupdate_schedule: monthly
+  autoupdate_schedule: quarterly # We want to do updates via renovate since we can exclude hooks from being updated
   autofix_commit_msg: 'style: pre-commit.ci fixes'
   skip:
     - poetry-lock

--- a/poetry.lock
+++ b/poetry.lock
@@ -248,13 +248,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "pyfakefs"
-version = "5.7.3"
+version = "5.7.4"
 description = "pyfakefs implements a fake file system that mocks the Python file system modules."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyfakefs-5.7.3-py3-none-any.whl", hash = "sha256:53702780b38b24a48a9b8481c971abf1675f5abfd7d44653c2bcdd90b9751224"},
-    {file = "pyfakefs-5.7.3.tar.gz", hash = "sha256:cd53790761d0fc030a9cf41fd541bfd28c1ea681b1a7c5df8834f3c9e511ac5f"},
+    {file = "pyfakefs-5.7.4-py3-none-any.whl", hash = "sha256:3e763d700b91c54ade6388be2cfa4e521abc00e34f7defb84ee511c73031f45f"},
+    {file = "pyfakefs-5.7.4.tar.gz", hash = "sha256:4971e65cc80a93a1e6f1e3a4654909c0c493186539084dc9301da3d68c8878fe"},
 ]
 
 [[package]]
@@ -479,13 +479,13 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.28.1"
+version = "20.29.0"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb"},
-    {file = "virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329"},
+    {file = "virtualenv-20.29.0-py3-none-any.whl", hash = "sha256:c12311863497992dc4b8644f8ea82d3b35bb7ef8ee82e6630d76d0197c39baf9"},
+    {file = "virtualenv-20.29.0.tar.gz", hash = "sha256:6345e1ff19d4b1296954cee076baaf58ff2a12a84a338c62b02eda39f20aa982"},
 ]
 
 [package.dependencies]

--- a/renovate.json
+++ b/renovate.json
@@ -2,14 +2,28 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    "schedule:monthly"
+    "schedule:monthly",
+    ":enablePreCommit"
   ],
   "packageRules": [
+    {
+      "enabled": false,
+      "matchPackageNames": [
+        "asottile/blacken-docs",
+        "asottile/pyupgrade",
+        "executablebooks/mdformat",
+        "pappasam/toml-sort",
+        "PyCQA/docformatter",
+        "python-poetry/poetry",
+        "tcort/markdown-link-check"
+      ]
+    },
     {
       "groupName": "{{packageFileDir}} dependency updates",
       "matchManagers": [
         "poetry",
-        "pip_requirements"
+        "pip_requirements",
+        "pre-commit"
       ]
     }
   ]


### PR DESCRIPTION
pre-commit.ci is always autoupdating all hooks, even the onces no longer supported on Python 3.8. In renovate, we can exclude some of the hooks.

I cannot completely disable pre-commit ci autoupdates, but only set it to the least frequent update cycle: https://pre-commit.ci/#configuration-autoupdate_schedule