### PR TITLE
Prevent autoupdates for > Python 3.8 deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,18 @@
       ]
     },
     {
+      "allowedVersions": "<=3.5.0",
+      "matchPackageNames": [
+        "pre-commit"
+      ]
+    },
+    {
+      "allowedVersions": "<2.0.0",
+      "matchPackageNames": [
+        "poetry"
+      ]
+    },
+    {
       "groupName": "{{packageFileDir}} dependency updates",
       "matchManagers": [
         "poetry",


### PR DESCRIPTION
We don't want renovate to create autoupdate PRs for deps that don't support our mininal version.