### PR TITLE
Extend check-shellscript-set-options hook to any shebang

### DIFF
--- a/dev_tools/check_shellscript_set_options.py
+++ b/dev_tools/check_shellscript_set_options.py
@@ -22,6 +22,7 @@ def _is_valid_shell_file(filename: Path, expected_options: str) -> bool:
     return any(_sets_options_or_is_nolint(line, expected_options) for line in lines)
 
 
+# Use the equivalent from identify once #80 is resolved
 def _does_shebang_match(program: str, first_line: str) -> bool:
     match = re.match(rf"^#!.*{program}", first_line)
     return match is not None

--- a/dev_tools/check_shellscript_set_options.py
+++ b/dev_tools/check_shellscript_set_options.py
@@ -23,8 +23,8 @@ def _is_valid_shell_file(filename: Path, expected_options: str) -> bool:
 
 
 def _does_shebang_match(program: str, first_line: str) -> bool:
-    matches = re.match(rf"^#!.*{program}", first_line)
-    return matches is not None
+    match = re.match(rf"^#!.*{program}", first_line)
+    return match is not None
 
 
 def _separate_bash_from_sh_files(filenames: Sequence[Path]) -> tuple[list[Path], list[Path]]:

--- a/dev_tools/check_shellscript_set_options.py
+++ b/dev_tools/check_shellscript_set_options.py
@@ -21,14 +21,19 @@ def _is_valid_shell_file(filename: Path, expected_options: str) -> bool:
     return any(_sets_options_or_is_nolint(line, expected_options) for line in lines)
 
 
+def _get_possible_shebangs(program: str) -> tuple[str, ...]:
+    shebang_possibilities = ("#!/bin/{}", "#!/usr/bin/{}", "#!/usr/bin/env {}")
+    return tuple(shebang.format(program) for shebang in shebang_possibilities)
+
+
 def _separate_bash_from_sh_files(filenames: Sequence[Path]) -> tuple[list[Path], list[Path]]:
     bash_files = []
     sh_files = []
     for filename in filenames:
         first_line = filename.open().readline()
-        if first_line.startswith(("#!/bin/bash", "#!/usr/bin/bash")):
+        if first_line.startswith(_get_possible_shebangs("bash")):
             bash_files.append(filename)
-        elif first_line.startswith(("#!/bin/sh", "#!/usr/bin/sh")):
+        elif first_line.startswith(_get_possible_shebangs("sh")):
             sh_files.append(filename)
         else:
             msg = f"Unknown shell in {filename}: {first_line}. Only use this hook in combination with 'check-executables-have-shebangs' from https://github.com/pre-commit/pre-commit-hooks"

--- a/tests/test_check_shellscript_set_options.py
+++ b/tests/test_check_shellscript_set_options.py
@@ -44,12 +44,25 @@ def test_pass_for_sh_file(fs: FakeFilesystem) -> None:
     fs.create_file(
         file,
         contents="""#!/bin/sh
-# set -eux
+set -eux
 date
 """,
     )
 
-    assert main([str(file)]) == 1
+    assert main([str(file)]) == 0
+
+
+def test_pass_for_sh_file_from_env(fs: FakeFilesystem) -> None:
+    file = "sh_file.sh"
+    fs.create_file(
+        file,
+        contents="""#!/usr/bin/env sh
+set -eux
+date
+""",
+    )
+
+    assert main([str(file)]) == 0
 
 
 def test_one_valid_and_one_invalid_file(fs: FakeFilesystem) -> None:
@@ -57,7 +70,7 @@ def test_one_valid_and_one_invalid_file(fs: FakeFilesystem) -> None:
     fs.create_file(
         valid_file,
         contents="""#!/bin/sh
-# set -eux
+set -eux
 date
 """,
     )
@@ -66,7 +79,7 @@ date
     fs.create_file(
         invalid_file,
         contents="""#!/bin/bash
-# set -eux
+set -eux
 date
 """,
     )


### PR DESCRIPTION
#77 the hook doesn't respect shebangs that utilize `/usr/bin/env` yet.