### PR TITLE
Run poetry-lock with no-update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,7 @@ repos:
     hooks:
       - id: poetry-check
       - id: poetry-lock
+        args: [--no-update]
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:


### PR DESCRIPTION
We want the lock file to be stable over time and not be updated if rerun it 2 weeks later
