### PR TITLE
Set project version during release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')
+          sed -i "s/version = \"0.0.0\" # Will be set by the release pipeline/version = \"$VERSION\"/" pyproject.toml
       - uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.1.1
         with:
           draft: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ warn_unused_ignores = true
 
 [tool.poetry]
 name = "dev-tools"
-version = "0.9.0"
+version = "0.0.0" # Will be set by the release pipeline
 description = ""
 authors = ["BRE <bre@luminartech.com>"]
 readme = "README.md"


### PR DESCRIPTION
Right now the version in the pyproject.toml is outdated, probably because it is unused at the
moment. This resets the version and uses the release pipeline to set the version from the tag. This
prepares python package releases from our release pipeline.

Merge after #84.

