### PR TITLE
Remove renovate config check hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -206,8 +206,3 @@ repos:
     hooks:
       - id: vulture
         pass_filenames: true
-# Enable once https://github.com/renovatebot/pre-commit-hooks/issues/2460 is resolved
-#   - repo: https://github.com/renovatebot/pre-commit-hooks
-#     rev: 38.77.3
-#     hooks:
-#       - id: renovate-config-validator


### PR DESCRIPTION
https://github.com/renovatebot/pre-commit-hooks/issues/2460 is now fixed and we could enable this again. However, it exceeds our pre-commit CI agent size. I don't see any value for depending on such a big hooks for a single rarely changing config file. Plus, we still have the json spec validation hook.

Fixes https://github.com/luminartech/dev-tools/issues/32.