### PR TITLE
Do not group pip and poetry

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,8 +38,6 @@
     {
       "groupName": "{{packageFileDir}} dependency updates",
       "matchManagers": [
-        "poetry",
-        "pip_requirements",
         "pre-commit"
       ]
     }


### PR DESCRIPTION
Turns out that renovate groups all of them in the list and we don't want to group pre-commit updates with poetry updates