### PR TITLE
Fix the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,7 @@ jobs:
         run: |
           export VERSION=${{ github.ref_name }}
           echo "Using version: $VERSION"
-          sed -i "s/version = \"0.0.0\" # Will be set by the release pipeline/version = \"$VERSION\"/" pyproject.toml
-          grep version pyproject.toml
+          grep "version = \"$VERSION\"" pyproject.toml || (echo "Version mismatch in pyproject.toml vs the tag name" && exit 1)
       - uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           draft: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,12 @@ pip3 install -e .
 ```
 
 That will install the tools in editable mode, meaning that your code changes will be visible as soon as you run the scripts again.
+
+## Creating a release
+
+To release a new version of dev-tools:
+
+1. update the pyproject.toml `version` field,
+1. put up a PR and get it merged to master,
+1. once merged, create a tag with the same version and push it,
+1. a release pipeline will run automatically and push a release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ warn_unused_ignores = true
 
 [tool.poetry]
 name = "dev-tools"
-version = "0.0.0" # Will be set by the release pipeline
+version = "0.13.2" # Will be read by the release pipeline
 description = ""
 authors = ["BRE <bre@luminartech.com>"]
 readme = "README.md"


### PR DESCRIPTION
The previous release mechanism was broken. It did replace the version in pyproject.toml, but the release archive was uploaded with the old contents.