### PR TITLE
Move pre-commit metrics into a separate hook

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,9 +31,9 @@ jobs:
       - name: Run test suite
         run: tox -e py
 
-  show-excluded-files-count:
+  e2e-tests:
     runs-on: ubuntu-latest
-    name: show excluded files count
+    name: run pre-commit try-repo on all files
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup python
@@ -43,4 +43,4 @@ jobs:
       - name: Install pre-commit
         run: python -m pip install pre-commit
       - name: Run pre-commit to show excluded files
-        run: pre-commit run check-non-existing-and-duplicate-excludes --verbose
+        run: pre-commit try-repo . print-pre-commit-metrics --all-files --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,6 @@ repos:
       - id: check-useless-excludes
   - repo: local
     hooks:
-      - id: check-non-existing-and-duplicate-excludes
-        name: Check non-existing and duplicate excludes in pre-commit-config
-        entry: dev_tools/check_useless_exclude_paths_hooks.py
-        pass_filenames: false
-        always_run: true
-        language: python
-        additional_dependencies: ["pre-commit >= 3.5.0"]
       - id: generate-hook-docs
         name: generate hook docs
         description: Generate markdown documentation for pre-commit hooks in README.md

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -103,10 +103,24 @@
     - svg
 - id: check-non-existing-and-duplicate-excludes
   name: Check non-existing and duplicate excludes in pre-commit-config
-  description: "Check for non existing and duplicate paths in `.pre-commit-config.yaml`. Background: In a big codebase, the exclude lists can be quite long and it's easy to make a typo or forget to remove an entry when it's no longer needed. If you run this hook with `--verbose` it will also print the number of excluded files for each hook."
+  description: |-
+    Check for non existing and duplicate paths in `.pre-commit-config.yaml`.
+
+    Background: In a big codebase, the exclude lists can be quite long and it's easy to make a typo or forget to remove an entry when it's no longer needed.
+    This hook helps you to maintain a clean and up to date exclude list.
   entry: check-useless-exclude-paths-hooks
   pass_filenames: false
   always_run: true
+  language: python
+  additional_dependencies: ["pre-commit >= 3.5.0"]
+- id: print-pre-commit-metrics
+  name: Print pre-commit metrics such as number of excluded files
+  description: |-
+    Count the number of excludes in `.pre-commit-config.yaml` and print them in json format.
+
+    On large projects this can help to collect metrics over time for how many files are excluded from pre-commit.
+  entry: print-pre-commit-metrics
+  pass_filenames: false
   language: python
   additional_dependencies: ["pre-commit >= 3.5.0"]
 - id: sync-vscode-config

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These tools are used to help developers in their day-to-day tasks.
   - [`check-shellscript-set-options`](#check-shellscript-set-options)
   - [`check-jira-reference-in-todo`](#check-jira-reference-in-todo)
   - [`check-non-existing-and-duplicate-excludes`](#check-non-existing-and-duplicate-excludes)
+  - [`print-pre-commit-metrics`](#print-pre-commit-metrics)
   - [`sync-vscode-config`](#sync-vscode-config)
   - [`check-ownership`](#check-ownership)
 - [Contributing](#contributing)
@@ -128,7 +129,16 @@ Check that all TODO comments follow the same pattern and link a Jira ticket: `TO
 
 ### `check-non-existing-and-duplicate-excludes`
 
-Check for non existing and duplicate paths in `.pre-commit-config.yaml`. Background: In a big codebase, the exclude lists can be quite long and it's easy to make a typo or forget to remove an entry when it's no longer needed. If you run this hook with `--verbose` it will also print the number of excluded files for each hook.
+Check for non existing and duplicate paths in `.pre-commit-config.yaml`.
+
+Background: In a big codebase, the exclude lists can be quite long and it's easy to make a typo or forget to remove an entry when it's no longer needed.
+This hook helps you to maintain a clean and up to date exclude list.
+
+### `print-pre-commit-metrics`
+
+Count the number of excludes in `.pre-commit-config.yaml` and print them in json format.
+
+On large projects this can help to collect metrics over time for how many files are excluded from pre-commit.
 
 ### `sync-vscode-config`
 

--- a/dev_tools/check_useless_exclude_paths_hooks.py
+++ b/dev_tools/check_useless_exclude_paths_hooks.py
@@ -1,12 +1,9 @@
-#!/usr/bin/env python
-
 # Copyright (c) Luminar Technologies, Inc. All rights reserved.
 # Licensed under the MIT License.
 
 from __future__ import annotations
 
 import itertools
-import json
 import sys
 from collections import Counter
 from pathlib import Path
@@ -113,24 +110,10 @@ def have_non_existent_paths_or_duplicates(hooks_list: list[Any]) -> bool:
     return bool(non_existing_paths or duplicates)
 
 
-def print_excluded_files_report(hooks_list: list[Any]) -> None:
-    hooks_with_excluded_files = [
-        {"hook_id": hook.id, "excluded_files_count": hook.count_excluded_files()}
-        for hook in hooks_list
-        if hook.count_excluded_files() > 0
-    ]
-    output_data = {
-        "total_excluded_files": sum(hook["excluded_files_count"] for hook in hooks_with_excluded_files),
-        "hooks": hooks_with_excluded_files,
-    }
-    print(json.dumps(output_data, indent=2))
-
-
 def main() -> int:
     repo_root = Path.cwd()
     pre_commit_config = repo_root / CONFIG_FILE
     hooks_list = load_hooks(repo_root, pre_commit_config)
-    print_excluded_files_report(hooks_list)
     return 1 if have_non_existent_paths_or_duplicates(hooks_list) else 0
 
 

--- a/dev_tools/print_pre_commit_metrics.py
+++ b/dev_tools/print_pre_commit_metrics.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from pre_commit.constants import CONFIG_FILE
+
+from dev_tools.check_useless_exclude_paths_hooks import Hook, load_hooks
+
+
+def print_excluded_files_report(hooks_list: list[Hook]) -> None:
+    hook_metrics_with_excluded_files: list[dict] = [
+        {"hook_id": hook.id, "excluded_files_count": hook.count_excluded_files()}
+        for hook in hooks_list
+        if hook.count_excluded_files() > 0
+    ]
+    output_data = {
+        "total_excluded_files": sum(
+            hook_metric["excluded_files_count"] for hook_metric in hook_metrics_with_excluded_files
+        ),
+        "hooks": hook_metrics_with_excluded_files,
+    }
+    print(json.dumps(output_data, indent=2))
+
+
+def main() -> int:
+    repo_root = Path.cwd()
+    pre_commit_config = repo_root / CONFIG_FILE
+    hooks_list = load_hooks(repo_root, pre_commit_config)
+    print_excluded_files_report(hooks_list)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ check-shellscript-set-options = "dev_tools.check_shellscript_set_options:main"
 check-useless-exclude-paths-hooks = "dev_tools.check_useless_exclude_paths_hooks:main"
 configure-vscode-for-bazel = "dev_tools.configure_vscode_for_bazel:main"
 generate-hook-docs = "dev_tools.generate_hook_docs:main"
+print-pre-commit-metrics = "dev_tools.print_pre_commit_metrics:main"
 sync-vscode-config = "dev_tools.sync_vscode_config:main"
 whoowns = "dev_tools.find_owner:main"
 


### PR DESCRIPTION
Make this a separate hook for performance reasons. This should not run every time a developer commits, but only when explicitly calling the hook.

Also improve the CI job to eat our own dog food.