### PR TITLE
Add e2e tests for pre-commit hooks

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,9 +31,9 @@ jobs:
       - name: Run test suite
         run: tox -e py
 
-  show-excluded-files-count:
+  e2e-tests:
     runs-on: ubuntu-latest
-    name: show excluded files count
+    name: run pre-commit try-repo on all files
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup python
@@ -43,4 +43,4 @@ jobs:
       - name: Install pre-commit
         run: python -m pip install pre-commit
       - name: Run pre-commit to show excluded files
-        run: pre-commit run check-non-existing-and-duplicate-excludes --verbose
+        run: SKIP=check-jira-reference-in-todo,check-ownership,go-revive,go-fmt,go-imports pre-commit try-repo . --all-files --verbose


### PR DESCRIPTION
Once #125 is merged we can even do more e2e testing. The hooks currently skipped either don't make sense on this repo or don't work yet. I will create a follow up issue to track this.