### PR TITLE
Fix UTF-8 encoding issue in check-shellscript-set-options

### DIFF
--- a/dev_tools/check_shellscript_set_options.py
+++ b/dev_tools/check_shellscript_set_options.py
@@ -24,7 +24,7 @@ def _sets_options_or_is_nolint(line: str, expected_options: str) -> bool:
 
 
 def _is_valid_shell_file(filename: Path, expected_options: str) -> bool:
-    lines = filename.read_text(encoding='utf-8').splitlines()
+    lines = filename.read_text(encoding="utf-8").splitlines()
     return any(_sets_options_or_is_nolint(line, expected_options) for line in lines)
 
 
@@ -39,7 +39,7 @@ def _separate_bash_from_sh_files(filenames: Sequence[Path]) -> tuple[bool, list[
     sh_files = []
     all_valid = True
     for filename in filenames:
-        first_line = filename.open(encoding='utf-8').readline()
+        first_line = filename.open(encoding="utf-8").readline()
         if _does_shebang_match("bash", first_line) or filename.suffix == ".bash":
             bash_files.append(filename)
         elif _does_shebang_match("sh", first_line):

--- a/dev_tools/check_shellscript_set_options.py
+++ b/dev_tools/check_shellscript_set_options.py
@@ -24,7 +24,7 @@ def _sets_options_or_is_nolint(line: str, expected_options: str) -> bool:
 
 
 def _is_valid_shell_file(filename: Path, expected_options: str) -> bool:
-    lines = filename.read_text().splitlines()
+    lines = filename.read_text(encoding='utf-8').splitlines()
     return any(_sets_options_or_is_nolint(line, expected_options) for line in lines)
 
 
@@ -39,7 +39,7 @@ def _separate_bash_from_sh_files(filenames: Sequence[Path]) -> tuple[bool, list[
     sh_files = []
     all_valid = True
     for filename in filenames:
-        first_line = filename.open().readline()
+        first_line = filename.open(encoding='utf-8').readline()
         if _does_shebang_match("bash", first_line) or filename.suffix == ".bash":
             bash_files.append(filename)
         elif _does_shebang_match("sh", first_line):


### PR DESCRIPTION
The check-shellscript-set-options hook fails on Windows when processing shell scripts containing UTF-8 characters (e.g., emojis) because it opens files without specifying an encoding, defaulting to cp1252 on Windows.

This commit adds explicit UTF-8 encoding when reading files to ensure cross-platform compatibility.

Fixes the error:
  UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3176:
  character maps to <undefined>

Changes:
- filename.read_text() -> filename.read_text(encoding='utf-8')
- filename.open().readline() -> filename.open(encoding='utf-8').readline()